### PR TITLE
Add Staging Infrastructure and pipeline ammendments 

### DIFF
--- a/terraform/environment/staging/main.tf
+++ b/terraform/environment/staging/main.tf
@@ -1,0 +1,31 @@
+provider "aws" {
+  region = "eu-west-1"
+}
+
+terraform {
+  backend "s3" {
+    bucket = "terraform-state-sfc-staging"
+    key    = "state/terraform.tfstate"
+    region = "eu-west-1"
+  }
+}
+module "frontend" {
+  source = "../../modules/frontend"
+
+  environment = var.environment
+}
+
+module "backend" {
+  source = "../../modules/backend"
+
+  environment        = var.environment
+  app_runner_cpu     = var.app_runner_cpu
+  app_runner_memory  = var.app_runner_memory
+  private_subnet_ids = module.networking.private_subnets
+  security_group_ids = module.networking.security_group_id
+}
+
+module "networking" {
+  source = "../../modules/networking"
+}
+

--- a/terraform/environment/staging/terraform.tfvars
+++ b/terraform/environment/staging/terraform.tfvars
@@ -1,0 +1,3 @@
+environment       = "staging"
+app_runner_cpu    = 256
+app_runner_memory = 512

--- a/terraform/environment/staging/variable.tf
+++ b/terraform/environment/staging/variable.tf
@@ -1,0 +1,14 @@
+variable "environment" {
+  description = "Name of environment we're deploying to"
+  type        = string
+}
+
+variable "app_runner_cpu" {
+  description = "The CPU size you wish to use on AWS App Runner"
+  type        = number
+}
+
+variable "app_runner_memory" {
+  description = "The memory size you wish to use on AWS App Runner"
+  type        = number
+}

--- a/terraform/modules/backend/app_runner.tf
+++ b/terraform/modules/backend/app_runner.tf
@@ -20,7 +20,7 @@ resource "aws_apprunner_service" "sfc_app_runner" {
       access_role_arn = aws_iam_role.app_runner_erc_access_role.arn
     }
     image_repository {
-      image_identifier      = "${aws_ecr_repository.sfc_backend_ecr_repository.repository_url}:latest"
+      image_identifier      = "636146736465.dkr.ecr.eu-west-1.amazonaws.com/sfc-backend-build-images:latest"
       image_repository_type = "ECR"
       image_configuration {
         port = 3000

--- a/terraform/modules/backend/ecr.tf
+++ b/terraform/modules/backend/ecr.tf
@@ -1,3 +1,0 @@
-resource "aws_ecr_repository" "sfc_backend_ecr_repository" {
-  name = "ecr-sfc-backend-${var.environment}"
-}

--- a/terraform/modules/pipeline/codebuild.tf
+++ b/terraform/modules/pipeline/codebuild.tf
@@ -106,7 +106,7 @@ resource "aws_codebuild_project" "codebuild_asc_wds_build" {
 resource "aws_codebuild_project" "codebuild_asc_wds_build_test_frontend" {
   name          = "asc-wds-build-test-frontend"
   description   = "test the asc-wds application frontend"
-  build_timeout = "5"
+  build_timeout = "10"
   service_role  = aws_iam_role.codebuild_role.arn
 
   artifacts {
@@ -141,7 +141,7 @@ resource "aws_codebuild_project" "codebuild_asc_wds_build_test_frontend" {
 resource "aws_codebuild_project" "codebuild_asc_wds_build_test_backend" {
   name          = "asc-wds-build-test-backend"
   description   = "test the asc-wds application backend"
-  build_timeout = "5"
+  build_timeout = "10"
   service_role  = aws_iam_role.codebuild_role.arn
 
   artifacts {
@@ -177,7 +177,7 @@ resource "aws_codebuild_project" "codebuild_asc_wds_build_test_backend" {
 resource "aws_codebuild_project" "codebuild_asc_wds_build_test_performance" {
   name          = "asc-wds-build-test-performance"
   description   = "test the asc-wds application performance"
-  build_timeout = "5"
+  build_timeout = "10"
   service_role  = aws_iam_role.codebuild_role.arn
 
   artifacts {
@@ -212,7 +212,7 @@ resource "aws_codebuild_project" "codebuild_asc_wds_build_test_performance" {
 resource "aws_codebuild_project" "codebuild_asc_wds_build_deploy_frontend" {
   name          = "asc-wds-build-deploy-frontend"
   description   = "deploy the asc-wds application frontend"
-  build_timeout = "5"
+  build_timeout = "10"
   service_role  = aws_iam_role.codebuild_role.arn
 
   artifacts {
@@ -247,7 +247,7 @@ resource "aws_codebuild_project" "codebuild_asc_wds_build_deploy_frontend" {
 resource "aws_codebuild_project" "codebuild_asc_wds_build_deploy_backend" {
   name          = "asc-wds-build-deploy-backend"
   description   = "deploy the asc-wds application backend"
-  build_timeout = "5"
+  build_timeout = "10"
   service_role  = aws_iam_role.codebuild_role.arn
 
   artifacts {

--- a/terraform/modules/pipeline/codebuild.tf
+++ b/terraform/modules/pipeline/codebuild.tf
@@ -284,3 +284,38 @@ resource "aws_codebuild_project" "codebuild_asc_wds_build_deploy_backend" {
     }
   }
 }
+
+resource "aws_codebuild_project" "codebuild_asc_wds_deploy_staging" {
+  name          = "asc-wds-deploy-staging"
+  description   = "deploy the asc-wds application to the staging environment"
+  build_timeout = "5"
+  service_role  = aws_iam_role.codebuild_role.arn
+
+  artifacts {
+    type = "NO_ARTIFACTS"
+  }
+
+  environment {
+    compute_type                = "BUILD_GENERAL1_MEDIUM"
+    image                       = "aws/codebuild/standard:7.0"
+    type                        = "LINUX_CONTAINER"
+    image_pull_credentials_type = "CODEBUILD"
+  }
+
+  logs_config {
+    cloudwatch_logs {
+      group_name  = "/aws/codebuild/asc-wds-deploy/staging"
+    }
+  }
+
+  source {
+    type            = "GITHUB"
+    location        = "https://github.com/NMDSdevopsServiceAdm/SFC-Migration-Test.git" 
+    git_clone_depth = 1
+    buildspec = "buildspec/deploy-staging.yml"
+
+    git_submodules_config {
+      fetch_submodules = true
+    }
+  }
+}

--- a/terraform/modules/pipeline/codepipeline.tf
+++ b/terraform/modules/pipeline/codepipeline.tf
@@ -164,7 +164,7 @@ resource "aws_codepipeline" "codepipeline_asc_wds_build" {
       category         = "Build"
       owner            = "AWS"
       provider         = "CodeBuild"
-      input_artifacts  = ["build_output"]
+      input_artifacts  = ["source_output"]
       output_artifacts = ["deploy_frontend_output"]
       version          = "1"
 

--- a/terraform/modules/pipeline/codepipeline.tf
+++ b/terraform/modules/pipeline/codepipeline.tf
@@ -114,7 +114,7 @@ resource "aws_codepipeline" "codepipeline_asc_wds_build" {
       category         = "Test"
       owner            = "AWS"
       provider         = "CodeBuild"
-      input_artifacts  = ["source_output"]
+      input_artifacts  = ["build_output"]
       output_artifacts = ["test_frontend_output"]
       version          = "1"
 
@@ -129,7 +129,7 @@ resource "aws_codepipeline" "codepipeline_asc_wds_build" {
       category         = "Test"
       owner            = "AWS"
       provider         = "CodeBuild"
-      input_artifacts  = ["source_output"]
+      input_artifacts  = ["build_output"]
       output_artifacts = ["test_backend_output"]
       version          = "1"
 
@@ -144,7 +144,7 @@ resource "aws_codepipeline" "codepipeline_asc_wds_build" {
       category         = "Test"
       owner            = "AWS"
       provider         = "CodeBuild"
-      input_artifacts  = ["source_output"]
+      input_artifacts  = ["build_output"]
       output_artifacts = ["test_performance_output"]
       version          = "1"
 
@@ -164,7 +164,7 @@ resource "aws_codepipeline" "codepipeline_asc_wds_build" {
       category         = "Build"
       owner            = "AWS"
       provider         = "CodeBuild"
-      input_artifacts  = ["source_output"]
+      input_artifacts  = ["build_output"]
       output_artifacts = ["deploy_frontend_output"]
       version          = "1"
 
@@ -179,7 +179,7 @@ resource "aws_codepipeline" "codepipeline_asc_wds_build" {
       category         = "Build"
       owner            = "AWS"
       provider         = "CodeBuild"
-      input_artifacts  = ["source_output"]
+      input_artifacts  = ["build_output"]
       output_artifacts = ["deploy_backend_output"]
       version          = "1"
 

--- a/terraform/modules/pipeline/ecr.tf
+++ b/terraform/modules/pipeline/ecr.tf
@@ -1,3 +1,29 @@
 resource "aws_ecr_repository" "sfc_backend_ecr_repository" {
   name = "sfc-backend-build-images"
 }
+data "aws_iam_policy_document" "cross_account_ecr_access_policy" {
+  statement {
+    sid    = "cross account ecr access policy"
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["101248264786"]
+    }
+
+    actions = [
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:BatchGetImage",
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:PutImage",
+      "ecr:InitiateLayerUpload",
+      "ecr:UploadLayerPart",
+      "ecr:CompleteLayerUpload"
+    ]
+  }
+}
+
+resource "aws_ecr_repository_policy" "cross_account_ecr_access_policy" {
+  repository = aws_ecr_repository.sfc_backend_ecr_repository.name
+  policy     = data.aws_iam_policy_document.cross_account_ecr_access_policy.json
+}

--- a/terraform/modules/pipeline/iam.tf
+++ b/terraform/modules/pipeline/iam.tf
@@ -42,6 +42,7 @@ data "aws_iam_policy_document" "codebuildservicerole_policy" {
       "ecr:ListTagsForResource",
       "ecr:PutImage",
       "ecr:UploadLayerPart",
+      "ecr:GetRepositoryPolicy",
       "codestar-connections:*",
       "codepipeline:*",
       "codecommit:GitPull",

--- a/terraform/modules/pipeline/iam.tf
+++ b/terraform/modules/pipeline/iam.tf
@@ -139,6 +139,7 @@ data "aws_iam_policy_document" "codebuildservicerole_policy" {
       aws_codebuild_project.codebuild_asc_wds_build_test_performance.arn,
       aws_codebuild_project.codebuild_asc_wds_build_deploy_frontend.arn,
       aws_codebuild_project.codebuild_asc_wds_build_deploy_backend.arn,
+      aws_codebuild_project.codebuild_asc_wds_deploy_staging.arn
       ]
   }
 

--- a/terraform/modules/pipeline/iam.tf
+++ b/terraform/modules/pipeline/iam.tf
@@ -34,6 +34,7 @@ data "aws_iam_policy_document" "codebuildservicerole_policy" {
       "ecr:GetAuthorizationToken",
       "ecr:BatchGetImage",
       "ecr:BatchCheckLayerAvailability",
+      "ecr:BatchDeleteImage",
       "ecr:CompleteLayerUpload",
       "ecr:DescribeImages",
       "ecr:DescribeRepositories",


### PR DESCRIPTION
- Change the input artifacts to get the build output 
- Increase the timeout for the test and build stages
- Add ECR policy so staging can pull images from build and deploy
- Change the URL for the app runner to pull the image from the build and deploy ECR 
- Add staging infrastructure 
- Add deploy to staging codebuild project