### PR TITLE
Create codebuild grouped aws managed policy

### DIFF
--- a/terraform/modules/cross_account_access/iam.tf
+++ b/terraform/modules/cross_account_access/iam.tf
@@ -61,19 +61,136 @@ resource "aws_iam_role_policy_attachment" "attach_codebuild_terraform_state_buck
   policy_arn = aws_iam_policy.codebuild_terraform_state_bucket_policy.arn
 }
 
-resource "aws_iam_role_policy_attachment" "attach_managed_aws_policies" {
-  for_each = toset([
-    "arn:aws:iam::aws:policy/AWSAppRunnerFullAccess",
-    "arn:aws:iam::aws:policy/AmazonVPCFullAccess",
-    "arn:aws:iam::aws:policy/IAMFullAccess",
-    "arn:aws:iam::aws:policy/AmazonSSMFullAccess",
-    "arn:aws:iam::aws:policy/AmazonRDSFullAccess",
-    "arn:aws:iam::aws:policy/AmazonS3FullAccess",
-    "arn:aws:iam::aws:policy/AmazonEC2FullAccess",
-    "arn:aws:iam::aws:policy/AmazonElastiCacheFullAccess",
-    "arn:aws:iam::aws:policy/CloudFrontFullAccess"
-  ])
+data "aws_iam_policy_document" "codebuild_grouped_aws_managed_policy" {
+  statement {
+    sid    = "AmazonEC2FullAccess"
+    effect = "Allow"
+    actions = [
+      "ec2:*",
+      "elasticloadbalancing:*",
+      "cloudwatch:*",
+      "autoscaling:*"
+    ]
+    resources = ["*"]
+  }
 
+  statement {
+    sid    = "AmazonElastiCacheFullAccess"
+    effect = "Allow"
+    actions = [
+      "elasticache:*"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "AmazonRDSFullAccess"
+    effect = "Allow"
+    actions = [
+      "rds:*",
+      "application-autoscaling:DeleteScalingPolicy",
+      "application-autoscaling:DeregisterScalableTarget",
+      "application-autoscaling:DescribeScalableTargets",
+      "application-autoscaling:DescribeScalingActivities",
+      "application-autoscaling:DescribeScalingPolicies",
+      "application-autoscaling:PutScalingPolicy",
+      "application-autoscaling:RegisterScalableTarget",
+      "sns:ListSubscriptions",
+      "sns:ListTopics",
+      "sns:Publish",
+      "outposts:GetOutpostInstanceTypes",
+      "devops-guru:GetResourceCollection"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid     = "AmazonRDSFullAccess1"
+    effect  = "Allow"
+    actions = ["pi:*"]
+    resources = [
+      "arn:aws:pi:*:*:metrics/rds/*",
+      "arn:aws:pi:*:*:perf-reports/rds/*"
+    ]
+  }
+
+  statement {
+    sid    = "AmazonS3FullAccess"
+    effect = "Allow"
+    actions = [
+      "s3:*",
+      "s3-object-lambda:*"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "AmazonSSMFullAccess"
+    effect = "Allow"
+    actions = [
+      "ds:CreateComputer",
+      "ds:DescribeDirectories",
+      "logs:*",
+      "ssm:*",
+      "ec2messages:*",
+      "ssmmessages:CreateControlChannel",
+      "ssmmessages:CreateDataChannel",
+      "ssmmessages:OpenControlChannel",
+      "ssmmessages:OpenDataChannel"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid       = "AWSAppRunnerFullAccess"
+    effect    = "Allow"
+    actions   = ["apprunner:*"]
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "IAMFullAccess"
+    effect = "Allow"
+    actions = [
+      "iam:*",
+      "organizations:DescribeAccount",
+      "organizations:DescribeOrganization",
+      "organizations:DescribeOrganizationalUnit",
+      "organizations:DescribePolicy",
+      "organizations:ListChildren",
+      "organizations:ListParents",
+      "organizations:ListPoliciesForTarget",
+      "organizations:ListRoots",
+      "organizations:ListPolicies",
+      "organizations:ListTargetsForPolicy"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "CloudFrontFullAccess"
+    effect = "Allow"
+    actions = [
+      "acm:ListCertificates",
+      "cloudfront:*",
+      "waf:ListWebACLs",
+      "waf:GetWebACL",
+      "wafv2:ListWebACLs",
+      "wafv2:GetWebACL",
+      "kinesis:ListStreams",
+      "kinesis:DescribeStream"
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "codebuild_grouped_aws_managed_policy" {
+  name        = "CodebuildGroupedAWSManagedPolicy"
+  description = "Contains all the polices that the Cross Account Role needs to deploy Terraform Infrastructure"
+  policy      = data.aws_iam_policy_document.codebuild_grouped_aws_managed_policy.json
+}
+
+resource "aws_iam_role_policy_attachment" "attach_codebuild_grouped_aws_managed_policy" {
   role       = aws_iam_role.codebuild_cross_account_access_service_role.name
-  policy_arn = each.value
+  policy_arn = aws_iam_policy.codebuild_grouped_aws_managed_policy.arn
 }

--- a/terraform/modules/cross_account_access/iam.tf
+++ b/terraform/modules/cross_account_access/iam.tf
@@ -70,7 +70,8 @@ resource "aws_iam_role_policy_attachment" "attach_managed_aws_policies" {
     "arn:aws:iam::aws:policy/AmazonRDSFullAccess",
     "arn:aws:iam::aws:policy/AmazonS3FullAccess",
     "arn:aws:iam::aws:policy/AmazonEC2FullAccess",
-    "arn:aws:iam::aws:policy/AmazonElastiCacheFullAccess"
+    "arn:aws:iam::aws:policy/AmazonElastiCacheFullAccess",
+    "arn:aws:iam::aws:policy/CloudFrontFullAccess"
   ])
 
   role       = aws_iam_role.codebuild_cross_account_access_service_role.name


### PR DESCRIPTION
Due to AWS allowing only 10 managed policies attached to a single role, we had to create a grouped policy including all of the AWS managed policies required to perform terraform action.