### PR TITLE
Handle 404 error response in cloudfront and s3

### DIFF
--- a/terraform/modules/frontend/cloudfront.tf
+++ b/terraform/modules/frontend/cloudfront.tf
@@ -33,6 +33,12 @@ resource "aws_cloudfront_distribution" "sfc_frontend_distribution" {
     max_ttl                = 86400
   }
 
+  custom_error_response {
+    error_caching_min_ttl = 10
+    error_code = 404
+    response_code = 404
+    response_page_path = "/index.html"
+  }
 
   restrictions {
     geo_restriction {

--- a/terraform/modules/frontend/s3.tf
+++ b/terraform/modules/frontend/s3.tf
@@ -28,6 +28,9 @@ resource "aws_s3_bucket_website_configuration" "sfc_frontend_bucket_website_conf
   index_document {
     suffix = "index.html"
   }
+  error_document {
+    key = "index.html"
+  }
 }
 
 resource "aws_s3_bucket_policy" "sfc_frontend_bucket_policy" {


### PR DESCRIPTION
- Added custom error response to the cloudfront
- Added error document to the s3 bucket static website configuration 