### PR TITLE
Apply RDS & Elasticache changes immediately

### DIFF
--- a/terraform/modules/backend/elasticache.tf
+++ b/terraform/modules/backend/elasticache.tf
@@ -12,6 +12,7 @@ resource "aws_elasticache_replication_group" "sfc_redis_replication_group" {
   port                        = 6379
   subnet_group_name  = aws_elasticache_subnet_group.sfc_redis_elasticache_subnet_group.name
   security_group_ids = var.security_group_ids
+  apply_immediately = true
 
   lifecycle {
     ignore_changes = [num_cache_clusters]
@@ -22,4 +23,5 @@ resource "aws_elasticache_cluster" "sfc_redis_replica" {
   count = 1
   cluster_id           = "sfc-redis-${var.environment}-${count.index}"
   replication_group_id = aws_elasticache_replication_group.sfc_redis_replication_group.id
+  apply_immediately = true
 }

--- a/terraform/modules/backend/rds.tf
+++ b/terraform/modules/backend/rds.tf
@@ -12,6 +12,7 @@ resource "aws_db_instance" "sfc_rds_db" {
   multi_az             = var.multi_az
   vpc_security_group_ids = var.security_group_ids
   backup_retention_period = var.rds_db_backup_retention_period
+  apply_immediately = true
 }
 
 resource "aws_db_subnet_group" "sfc_rds_db_subnet_group" {


### PR DESCRIPTION
This PR is a temporary fix to ensure our changes to RDS and Elasticache get applied immediately. This will be reverted once we go live or when we feel we will not be making any more regular changes.