### PR TITLE
Serve /api via Cloudfront; Add missing env vars; RDS configuration changes

### DIFF
--- a/terraform/environment/benchmark/main.tf
+++ b/terraform/environment/benchmark/main.tf
@@ -32,6 +32,7 @@ module "backend" {
   app_runner_max_container_instances_size = var.app_runner_max_container_instances_size
   app_runner_max_concurrency = var.app_runner_max_concurrency
   rds_db_backup_retention_period = var.rds_db_backup_retention_period
+  node_env                                = var.node_env
 }
 
 module "networking" {

--- a/terraform/environment/benchmark/main.tf
+++ b/terraform/environment/benchmark/main.tf
@@ -14,6 +14,7 @@ module "frontend" {
 
   environment = var.environment
   domain_name = var.domain_name
+  app_runner_url = var.app_runner_url
 }
 
 module "backend" {

--- a/terraform/environment/benchmark/terraform.tfvars
+++ b/terraform/environment/benchmark/terraform.tfvars
@@ -1,6 +1,6 @@
 environment       = "benchmark"
-app_runner_cpu    = "0.25 vCPU"
-app_runner_memory = "0.5 GB"
+app_runner_cpu    = "0.5 vCPU"
+app_runner_memory = "1 GB"
 rds_instance_class = "db.t3.small"
 rds_allocated_storage = 20
 multi_az = false

--- a/terraform/environment/benchmark/terraform.tfvars
+++ b/terraform/environment/benchmark/terraform.tfvars
@@ -8,6 +8,7 @@ elasticache_node_type = "cache.t3.micro"
 app_runner_min_container_instances_size = 1
 app_runner_max_container_instances_size = 1
 app_runner_max_concurrency = 200
+app_runner_url = "rqhb8dcq2a.eu-west-1.awsapprunner.com"
 rds_db_backup_retention_period = 7
 domain_name = "benchmarks.ascwds.co.uk"
 sfc_reports_instance_type = "t2.micro"

--- a/terraform/environment/benchmark/terraform.tfvars
+++ b/terraform/environment/benchmark/terraform.tfvars
@@ -11,3 +11,4 @@ app_runner_max_concurrency = 200
 rds_db_backup_retention_period = 7
 domain_name = "benchmarks.ascwds.co.uk"
 sfc_reports_instance_type = "t2.micro"
+node_env = "benchmarks"

--- a/terraform/environment/benchmark/variable.tf
+++ b/terraform/environment/benchmark/variable.tf
@@ -63,3 +63,8 @@ variable "node_env" {
   description = "The Node Environment Varible to use the correct config"
   type        = string
 }
+
+variable "app_runner_url" {
+  description = "The app runner url"
+  type        = string
+}

--- a/terraform/environment/benchmark/variable.tf
+++ b/terraform/environment/benchmark/variable.tf
@@ -58,3 +58,8 @@ variable "domain_name" {
 variable "sfc_reports_instance_type" {
   description = "The instance type for the sfc reports EC2 instance"
 }
+
+variable "node_env" {
+  description = "The Node Environment Varible to use the correct config"
+  type        = string
+}

--- a/terraform/environment/pre-production/main.tf
+++ b/terraform/environment/pre-production/main.tf
@@ -33,6 +33,7 @@ module "backend" {
   app_runner_max_container_instances_size = var.app_runner_max_container_instances_size
   app_runner_max_concurrency = var.app_runner_max_concurrency
   rds_db_backup_retention_period = var.rds_db_backup_retention_period
+  node_env                                = var.node_env
 }
 
 module "networking" {

--- a/terraform/environment/pre-production/main.tf
+++ b/terraform/environment/pre-production/main.tf
@@ -14,6 +14,7 @@ module "frontend" {
 
   environment = var.environment
   domain_name = var.domain_name
+  app_runner_url = var.app_runner_url
 }
 
 module "backend" {

--- a/terraform/environment/pre-production/terraform.tfvars
+++ b/terraform/environment/pre-production/terraform.tfvars
@@ -8,6 +8,7 @@ elasticache_node_type = "cache.t3.micro"
 app_runner_min_container_instances_size = 1
 app_runner_max_container_instances_size = 1
 app_runner_max_concurrency = 200
+app_runner_url = "ztykfnse35.eu-west-1.awsapprunner.com"
 rds_db_backup_retention_period = 7
 domain_name = "preprod.ascwds.co.uk"
 sfc_reports_instance_type = "t3.large"

--- a/terraform/environment/pre-production/terraform.tfvars
+++ b/terraform/environment/pre-production/terraform.tfvars
@@ -1,6 +1,6 @@
 environment       = "preprod"
-app_runner_cpu    = "0.25 vCPU"
-app_runner_memory = "0.5 GB"
+app_runner_cpu    = "4 vCPU"
+app_runner_memory = "8 GB"
 rds_instance_class = "db.t3.medium"
 rds_allocated_storage = 100
 multi_az = false

--- a/terraform/environment/pre-production/terraform.tfvars
+++ b/terraform/environment/pre-production/terraform.tfvars
@@ -12,3 +12,4 @@ app_runner_url = "ztykfnse35.eu-west-1.awsapprunner.com"
 rds_db_backup_retention_period = 7
 domain_name = "preprod.ascwds.co.uk"
 sfc_reports_instance_type = "t3.large"
+node_env = "preproduction"

--- a/terraform/environment/pre-production/variable.tf
+++ b/terraform/environment/pre-production/variable.tf
@@ -63,3 +63,7 @@ variable "domain_name" {
 variable "sfc_reports_instance_type" {
   description = "The instance type for the sfc reports EC2 instance"
 }
+variable "node_env" {
+  description = "The Node Environment Varible to use the correct config"
+  type        = string
+}

--- a/terraform/environment/pre-production/variable.tf
+++ b/terraform/environment/pre-production/variable.tf
@@ -42,6 +42,11 @@ variable "app_runner_max_container_instances_size" {
   type = number
 }
 
+variable "app_runner_url" {
+  description = "The app runner url"
+  type        = string
+}
+
 variable "app_runner_max_concurrency" {
   description = "The maximum number of concurrency for a single AWS App runner container instance"
   type = number

--- a/terraform/environment/production/main.tf
+++ b/terraform/environment/production/main.tf
@@ -32,6 +32,7 @@ module "backend" {
   app_runner_max_container_instances_size = var.app_runner_max_container_instances_size
   app_runner_max_concurrency = var.app_runner_max_concurrency
   rds_db_backup_retention_period = var.rds_db_backup_retention_period
+  node_env                                = var.node_env
 }
 
 module "networking" {

--- a/terraform/environment/production/main.tf
+++ b/terraform/environment/production/main.tf
@@ -14,6 +14,7 @@ module "frontend" {
 
   environment = var.environment
   domain_name = var.domain_name
+  app_runner_url = va
 }
 
 module "backend" {

--- a/terraform/environment/production/main.tf
+++ b/terraform/environment/production/main.tf
@@ -14,7 +14,7 @@ module "frontend" {
 
   environment = var.environment
   domain_name = var.domain_name
-  app_runner_url = va
+  app_runner_url = var.app_runner_url
 }
 
 module "backend" {

--- a/terraform/environment/production/terraform.tfvars
+++ b/terraform/environment/production/terraform.tfvars
@@ -1,6 +1,6 @@
 environment       = "prod"
-app_runner_cpu    = "1 vCPU"
-app_runner_memory = "2 GB"
+app_runner_cpu    = "4 vCPU"
+app_runner_memory = "8 GB"
 rds_instance_class = "db.t3.2xlarge"
 rds_allocated_storage = 200
 multi_az = true

--- a/terraform/environment/production/terraform.tfvars
+++ b/terraform/environment/production/terraform.tfvars
@@ -11,3 +11,4 @@ app_runner_max_concurrency = 200
 rds_db_backup_retention_period = 35
 domain_name = "asc-wds.skillsforcare.org.uk"
 sfc_reports_instance_type = "t3.large"
+node_env = "production"

--- a/terraform/environment/production/terraform.tfvars
+++ b/terraform/environment/production/terraform.tfvars
@@ -8,6 +8,7 @@ elasticache_node_type = "cache.t3.micro"
 app_runner_min_container_instances_size = 2
 app_runner_max_container_instances_size = 25
 app_runner_max_concurrency = 200
+app_runner_url = "mnw9r2pi4a.eu-west-1.awsapprunner.com"
 rds_db_backup_retention_period = 35
 domain_name = "asc-wds.skillsforcare.org.uk"
 sfc_reports_instance_type = "t3.large"

--- a/terraform/environment/production/variable.tf
+++ b/terraform/environment/production/variable.tf
@@ -59,3 +59,8 @@ variable "domain_name" {
 variable "sfc_reports_instance_type" {
   description = "The instance type for the sfc reports EC2 instance"
 }
+
+variable "node_env" {
+  description = "The Node Environment Varible to use the correct config"
+  type        = string
+}

--- a/terraform/environment/production/variable.tf
+++ b/terraform/environment/production/variable.tf
@@ -42,7 +42,10 @@ variable "app_runner_max_container_instances_size" {
   description = "The maximum number of container instance for AWS App runner"
   type = number
 }
-
+variable "app_runner_url" {
+  description = "The app runner url"
+  type        = string
+}
 variable "app_runner_max_concurrency" {
   description = "The maximum number of concurrency for a single AWS App runner container instance"
   type = number

--- a/terraform/environment/staging/main.tf
+++ b/terraform/environment/staging/main.tf
@@ -33,6 +33,7 @@ module "backend" {
   app_runner_max_container_instances_size = var.app_runner_max_container_instances_size
   app_runner_max_concurrency              = var.app_runner_max_concurrency
   rds_db_backup_retention_period          = var.rds_db_backup_retention_period
+  node_env                                = var.node_env
 }
 
 module "networking" {

--- a/terraform/environment/staging/main.tf
+++ b/terraform/environment/staging/main.tf
@@ -14,6 +14,7 @@ module "frontend" {
 
   environment = var.environment
   domain_name = var.domain_name
+  app_runner_url = var.app_runner_url
 }
 
 module "backend" {

--- a/terraform/environment/staging/terraform.tfvars
+++ b/terraform/environment/staging/terraform.tfvars
@@ -1,6 +1,6 @@
 environment                             = "staging"
-app_runner_cpu                          = "0.25 vCPU"
-app_runner_memory                       = "0.5 GB"
+app_runner_cpu                          = "4 vCPU"
+app_runner_memory                       = "8 GB"
 rds_instance_class                      = "db.t3.small"
 rds_allocated_storage                   = 20
 multi_az                                = false

--- a/terraform/environment/staging/terraform.tfvars
+++ b/terraform/environment/staging/terraform.tfvars
@@ -8,6 +8,7 @@ elasticache_node_type                   = "cache.t3.micro"
 app_runner_min_container_instances_size = 1
 app_runner_max_container_instances_size = 1
 app_runner_max_concurrency              = 200
+app_runner_url = "a3akknuhui.eu-west-1.awsapprunner.com" 
 rds_db_backup_retention_period          = 7
 domain_name = "staging.ascwds.co.uk"
 sfc_reports_instance_type = "t2.micro"

--- a/terraform/environment/staging/terraform.tfvars
+++ b/terraform/environment/staging/terraform.tfvars
@@ -12,3 +12,4 @@ app_runner_url = "a3akknuhui.eu-west-1.awsapprunner.com"
 rds_db_backup_retention_period          = 7
 domain_name = "staging.ascwds.co.uk"
 sfc_reports_instance_type = "t2.micro"
+node_env = "test"

--- a/terraform/environment/staging/variable.tf
+++ b/terraform/environment/staging/variable.tf
@@ -42,6 +42,10 @@ variable "app_runner_max_container_instances_size" {
   type        = number
 }
 
+variable "app_runner_url" {
+  description = "The app runner url"
+  type        = string
+}
 variable "app_runner_max_concurrency" {
   description = "The maximum number of concurrency for a single AWS App runner container instance"
   type        = number

--- a/terraform/environment/staging/variable.tf
+++ b/terraform/environment/staging/variable.tf
@@ -62,3 +62,8 @@ variable "domain_name" {
 variable "sfc_reports_instance_type" {
   description = "The instance type for the sfc reports EC2 instance"
 }
+
+variable "node_env" {
+  description = "The Node Environment Varible to use the correct config"
+  type        = string
+}

--- a/terraform/modules/backend/app_runner.tf
+++ b/terraform/modules/backend/app_runner.tf
@@ -33,6 +33,8 @@ resource "aws_apprunner_service" "sfc_app_runner" {
           REDIS_ENDPOINT = aws_ssm_parameter.redis_endpoint.arn
           NODE_ENV       = aws_ssm_parameter.node_env.arn
           HONEYCOMB_WRITE_KEY = aws_ssm_parameter.honeycomb_write_key.arn
+          TOKEN_ISS = aws_ssm_parameter.token_iss.arn
+          TOKEN_SECRET = aws_ssm_parameter.token_secret.arn
         }
       }
     }

--- a/terraform/modules/backend/app_runner.tf
+++ b/terraform/modules/backend/app_runner.tf
@@ -31,6 +31,8 @@ resource "aws_apprunner_service" "sfc_app_runner" {
           DB_NAME        = aws_ssm_parameter.database_name.arn
           DB_HOST        = aws_ssm_parameter.database_host.arn
           REDIS_ENDPOINT = aws_ssm_parameter.redis_endpoint.arn
+          NODE_ENV       = aws_ssm_parameter.node_env.arn
+          HONEYCOMB_WRITE_KEY = aws_ssm_parameter.honeycomb_write_key.arn
         }
       }
     }

--- a/terraform/modules/backend/app_runner.tf
+++ b/terraform/modules/backend/app_runner.tf
@@ -35,6 +35,19 @@ resource "aws_apprunner_service" "sfc_app_runner" {
           HONEYCOMB_WRITE_KEY = aws_ssm_parameter.honeycomb_write_key.arn
           TOKEN_ISS = aws_ssm_parameter.token_iss.arn
           TOKEN_SECRET = aws_ssm_parameter.token_secret.arn
+          SLACK_URL = aws_ssm_parameter.slack_url.arn
+          NOTIFY_KEY = aws_ssm_parameter.notify_key.arn
+          ADMIN_URL = aws_ssm_parameter.admin_url.arn
+          GET_ADDRESS = aws_ssm_parameter.get_address.arn
+          SEND_IN_BLUE_KEY = aws_ssm_parameter.send_in_blue_key.arn
+          SEND_IN_BLUE_WHITELIST = aws_ssm_parameter.send_in_blue_whitelist.arn
+          # ENCRYPTION_PRIVATE_KEY = aws_ssm_parameter.encryption_private_key.arn
+          # ENCRYPTION_PUBLIC_KEY = aws_ssm_parameter.encryption_public_key.arn
+          ENCRYPTION_PASSPHRASE = aws_ssm_parameter.encryption_passphrase.arn
+          ENCRYPTION_REVOKECERT = aws_ssm_parameter.encryption_revokecert.arn
+          SEND_EMAILS_SQS_QUEUE = aws_ssm_parameter.send_emails_sqs_queue.arn
+          AWS_ACCESS_KEY_ID = aws_ssm_parameter.aws_access_key_id.arn
+          AWS_SECRET_ACCESS_KEY = aws_ssm_parameter.aws_secret_access_key.arn
         }
       }
     }

--- a/terraform/modules/backend/parameter_store.tf
+++ b/terraform/modules/backend/parameter_store.tf
@@ -38,3 +38,23 @@ resource "aws_ssm_parameter" "redis_endpoint" {
   type        = "String"
   value       = "redis://${aws_elasticache_replication_group.sfc_redis_replication_group.primary_endpoint_address}:6379"
 }
+
+resource "aws_ssm_parameter" "node_env" {
+  name        = "/${var.environment}/app_runner/node_env"
+  description = "The Node Environment Varible to use the correct config"
+  type        = "String"
+  value       = var.node_env
+}
+
+resource "aws_ssm_parameter" "honeycomb_write_key" {
+  name        = "/${var.environment}/app_runner/honeycomb_write_key"
+  description = "The honeycomb write key"
+  type        = "SecureString"
+  value       = "changeme"
+
+  lifecycle {
+    ignore_changes = [
+      value,
+    ]
+  }
+}

--- a/terraform/modules/backend/parameter_store.tf
+++ b/terraform/modules/backend/parameter_store.tf
@@ -58,3 +58,29 @@ resource "aws_ssm_parameter" "honeycomb_write_key" {
     ]
   }
 }
+
+resource "aws_ssm_parameter" "token_iss" {
+  name        = "/${var.environment}/app_runner/token_iss"
+  description = "The JWT issuer"
+  type        = "String"
+  value       = "changeme"
+
+  lifecycle {
+    ignore_changes = [
+      value,
+    ]
+  }
+}
+
+resource "aws_ssm_parameter" "token_secret" {
+  name        = "/${var.environment}/app_runner/token_secret"
+  description = "The JWT signing secret"
+  type        = "SecureString"
+  value       = "changeme"
+
+  lifecycle {
+    ignore_changes = [
+      value,
+    ]
+  }
+}

--- a/terraform/modules/backend/parameter_store.tf
+++ b/terraform/modules/backend/parameter_store.tf
@@ -84,3 +84,172 @@ resource "aws_ssm_parameter" "token_secret" {
     ]
   }
 }
+
+resource "aws_ssm_parameter" "slack_url" {
+  name        = "/${var.environment}/app_runner/slack_url"
+  description = "slack_url"
+  type        = "SecureString"
+  value       = "changeme"
+
+  lifecycle {
+    ignore_changes = [
+      value,
+    ]
+  }
+}
+
+resource "aws_ssm_parameter" "notify_key" {
+  name        = "/${var.environment}/app_runner/notify_key"
+  description = "NOTIFY_KEY"
+  type        = "SecureString"
+  value       = "changeme"
+
+  lifecycle {
+    ignore_changes = [
+      value,
+    ]
+  }
+}
+
+resource "aws_ssm_parameter" "admin_url" {
+  name        = "/${var.environment}/app_runner/admin_url"
+  description = "ADMIN_URL"
+  type        = "SecureString"
+  value       = "changeme"
+
+  lifecycle {
+    ignore_changes = [
+      value,
+    ]
+  }
+}
+
+resource "aws_ssm_parameter" "get_address" {
+  name        = "/${var.environment}/app_runner/get_address"
+  description = "GET_ADDRESS"
+  type        = "SecureString"
+  value       = "changeme"
+
+  lifecycle {
+    ignore_changes = [
+      value,
+    ]
+  }
+}
+
+resource "aws_ssm_parameter" "send_in_blue_key" {
+  name        = "/${var.environment}/app_runner/send_in_blue_key"
+  description = "SEND_IN_BLUE_KEY"
+  type        = "SecureString"
+  value       = "changeme"
+
+  lifecycle {
+    ignore_changes = [
+      value,
+    ]
+  }
+}
+
+resource "aws_ssm_parameter" "send_in_blue_whitelist" {
+  name        = "/${var.environment}/app_runner/send_in_blue_whitelist"
+  description = "SEND_IN_BLUE_WHITELIST"
+  type        = "SecureString"
+  value       = "changeme"
+
+  lifecycle {
+    ignore_changes = [
+      value,
+    ]
+  }
+}
+
+# resource "aws_ssm_parameter" "encryption_private_key" {
+#   name        = "/${var.environment}/app_runner/encryption_private_key"
+#   description = "ENCRYPTION_PRIVATE_KEY"
+#   type        = "SecureString"
+#   value       = "changeme"
+#   tier        = "Advanced"
+#   lifecycle {
+#     ignore_changes = [
+#       value,
+#     ]
+#   }
+# }
+
+# resource "aws_ssm_parameter" "encryption_public_key" {
+#   name        = "/${var.environment}/app_runner/encryption_public_key"
+#   description = "ENCRYPTION_PUBLIC_KEY"
+#   type        = "SecureString"
+#   value       = "changeme"
+#   tier        = "Advanced"
+#   lifecycle {
+#     ignore_changes = [
+#       value,
+#     ]
+#   }
+# }
+
+resource "aws_ssm_parameter" "encryption_passphrase" {
+  name        = "/${var.environment}/app_runner/encryption_passphrase"
+  description = "ENCRYPTION_PASSPHRASE"
+  type        = "SecureString"
+  value       = "changeme"
+
+  lifecycle {
+    ignore_changes = [
+      value,
+    ]
+  }
+}
+
+resource "aws_ssm_parameter" "encryption_revokecert" {
+  name        = "/${var.environment}/app_runner/encryption_revokecert"
+  description = "ENCRYPTION_REVOKECERT"
+  type        = "SecureString"
+  value       = "changeme"
+
+  lifecycle {
+    ignore_changes = [
+      value,
+    ]
+  }
+}
+
+resource "aws_ssm_parameter" "send_emails_sqs_queue" {
+  name        = "/${var.environment}/app_runner/send_emails_sqs_queue"
+  description = "SEND_EMAILS_SQS_QUEUE"
+  type        = "SecureString"
+  value       = "changeme"
+
+  lifecycle {
+    ignore_changes = [
+      value,
+    ]
+  }
+}
+
+resource "aws_ssm_parameter" "aws_access_key_id" {
+  name        = "/${var.environment}/app_runner/aws_access_key_id"
+  description = "AWS_ACCESS_KEY_ID"
+  type        = "SecureString"
+  value       = "changeme"
+
+  lifecycle {
+    ignore_changes = [
+      value,
+    ]
+  }
+}
+
+resource "aws_ssm_parameter" "aws_secret_access_key" {
+  name        = "/${var.environment}/app_runner/aws_secret_access_key"
+  description = "AWS_SECRET_ACCESS_KEY"
+  type        = "SecureString"
+  value       = "changeme"
+
+  lifecycle {
+    ignore_changes = [
+      value,
+    ]
+  }
+}

--- a/terraform/modules/backend/rds.tf
+++ b/terraform/modules/backend/rds.tf
@@ -3,7 +3,7 @@ resource "aws_db_instance" "sfc_rds_db" {
   instance_class      = var.rds_instance_class
   allocated_storage   = var.rds_allocated_storage
   engine              = "postgres"
-  engine_version      = "14.7"
+  engine_version      = "13.10"
   db_name             = "sfcdb_${random_string.sfc_rds_db_name_id.result}"
   username            = random_string.sfc_rds_db_username.result
   password            = random_password.sfc_rds_password.result

--- a/terraform/modules/backend/rds.tf
+++ b/terraform/modules/backend/rds.tf
@@ -13,6 +13,7 @@ resource "aws_db_instance" "sfc_rds_db" {
   vpc_security_group_ids = var.security_group_ids
   backup_retention_period = var.rds_db_backup_retention_period
   apply_immediately = true
+  storage_encrypted = true
 }
 
 resource "aws_db_subnet_group" "sfc_rds_db_subnet_group" {

--- a/terraform/modules/backend/varibles.tf
+++ b/terraform/modules/backend/varibles.tf
@@ -13,6 +13,11 @@ variable "app_runner_memory" {
   type        = string
 }
 
+variable "node_env" {
+  description = "The Node Environment Varible to use the correct config"
+  type        = string
+}
+
 variable "private_subnet_ids" {
   description = "The ID's of the private subnet used by the App Runner VPC connector"
 }

--- a/terraform/modules/frontend/cloudfront.tf
+++ b/terraform/modules/frontend/cloudfront.tf
@@ -10,6 +10,17 @@ resource "aws_cloudfront_distribution" "sfc_frontend_distribution" {
     }
   }
 
+  origin {
+    domain_name              = var.app_runner_url
+    origin_id                = var.app_runner_url
+  custom_origin_config {
+      http_port              = "80"
+      https_port             = "443"
+      origin_protocol_policy = "https-only"
+      origin_ssl_protocols   = ["TLSv1.2"]
+    }
+  }
+
   enabled             = true
   is_ipv6_enabled     = true
   comment             = "Couldfront distribution for ${var.environment}"

--- a/terraform/modules/frontend/cloudfront.tf
+++ b/terraform/modules/frontend/cloudfront.tf
@@ -45,6 +45,28 @@ resource "aws_cloudfront_distribution" "sfc_frontend_distribution" {
     max_ttl                = 86400
   }
 
+    ordered_cache_behavior {
+    path_pattern     = "api/*"
+    allowed_methods  = ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id = var.app_runner_url
+
+    forwarded_values {
+      query_string = true
+      headers      = ["Authorization"]
+
+      cookies {
+        forward = "all"
+      }
+    }
+
+    min_ttl                = 0
+    default_ttl            = 86400
+    max_ttl                = 31536000
+    compress               = true
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
   custom_error_response {
     error_caching_min_ttl = 10
     error_code = 404

--- a/terraform/modules/frontend/varibles.tf
+++ b/terraform/modules/frontend/varibles.tf
@@ -7,3 +7,8 @@ variable "domain_name" {
   description = "Domain name of environment"
   type        = string
 }
+
+variable "app_runner_url" {
+  description = "App Runner url"
+  type        = string
+}


### PR DESCRIPTION
- Add Cloudfront distribution to serve app runner on /api
- Add missing environment varibles.
- Increase resources on App Runner
- Change RDS to encrypt at rest
- Change RDS version to match GovPaaS